### PR TITLE
fix: Improve character render efficiency

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -146,10 +146,16 @@ var Engine = (function(global) {
         /* Loop through all of the objects within the allEnemies array and call
          * the render function you have defined.
          */
-        allEnemies.forEach(function(enemy) {
-            enemy.render();
-        });
+        const length = allEnemies.length;
+        for (let i = 0; i < length; ++i) {
+          let enemy = allEnemies.shift();
 
+          if (enemy.x < canvas.width) {
+            enemy.render();
+            allEnemies.push(enemy);
+          }
+        }
+        
         player.render();
     }
 


### PR DESCRIPTION
As in the **original code**, the size of `allEnemies` array will continuously grow as there is no removal of out of frame `enemy` and this would possibly lead to inefficient rendering and unnecessary space use as more and more enemies would be generated.

As in the proposed change, we only render `enemy` that is still within the canvas and push it back to `allEnemies` for next rendering. With this we are able to keep `allEnemies` in a small size and achieve a faster rendering of characters.

